### PR TITLE
Add `nlbq init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,19 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/google-service-account.json
 
 ```bash
 mkdir demo # Git will ignore this directory
+cd demo
 python3 -m venv venv
 source venv/bin/activate
 pip install -e ../ # Install the local package in editable mode
-nlbq init
+nlbq init  # generates prompt.txt, Dockerfile and index.html
 # make changes then
 pip uninstall nlbq --yes; pip install -e ../
+```
+
+You can initialise with prepopulated BigQuery dataset table schema information with
+
+```bash
+nlbq init --table dataset.table_id
 ```
 
 ## Usage

--- a/nlbq/cli.py
+++ b/nlbq/cli.py
@@ -3,12 +3,14 @@ import sys
 from asyncio import run
 from functools import wraps
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from tabulate import tabulate
 
 from nlbq.api import serve as api_serve
 from nlbq.core import DEFAULT_MODEL, NLBQ
+from nlbq.helpers import generate_prompt_from_dataset_table
 
 
 class AsyncTyper(typer.Typer):
@@ -50,20 +52,55 @@ async def ask(query: str, model: str = DEFAULT_MODEL) -> str:
     print("\n" + tabulate(rows, headers=fields, tablefmt="pipe") + "\n")
 
 
+def validate_table_format(table_in_dataset: str) -> str:
+    """Validate dataset format"""
+    if "." not in table_in_dataset:
+        raise typer.BadParameter(
+            "The target table value must be in the format dataset.table_id"
+        )
+    return table_in_dataset
+
+
 @app.command()
-def init():
+def init(
+    table_in_dataset: Annotated[
+        str,
+        typer.Option(
+            "--table",
+            "-t",
+            help="The target table in the form of dataset.table_id",
+            callback=validate_table_format,
+        ),
+    ] = None
+):
     """Create stub files: prompt.txt, index.html, Dockerfile"""
     package_dir = Path(__file__).parent
-    for file in ["Dockerfile", "index.html", "prompt.txt"]:
-        dest = Path.cwd() / file
+    current_dir = Path.cwd()
+    prefix_success = typer.style("✔", fg=typer.colors.GREEN, bold=True)
+    prefix_error = typer.style("✘", fg=typer.colors.RED, bold=True)
+
+    for file in ["Dockerfile", "index.html"]:
+        dest = current_dir / file
         if dest.exists():
-            prefix = typer.style("✘", fg=typer.colors.RED, bold=True)
-            typer.echo(f"{prefix} {file} already exists here")
+            typer.echo(f"{prefix_error} {file} already exists here")
             raise typer.Abort()
         else:
             shutil.copyfile(package_dir / "templates" / file, dest)
-            prefix = typer.style("✔", fg=typer.colors.GREEN, bold=True)
-            typer.echo(f"{prefix} Created {file} at {dest}")
+            typer.echo(f"{prefix_success} Created {file} at {dest}")
+
+    prompt_file = current_dir / "prompt.txt"
+    if prompt_file.exists():
+        typer.echo(f"{prefix_error} {file} already exists here")
+        raise typer.Abort()
+
+    if table_in_dataset:
+        shutil.copyfile(package_dir / "templates" / "prompt_template.txt", prompt_file)
+        print(f"⠹ Creating prompt.txt using {table_in_dataset}", end="\r")
+        generate_prompt_from_dataset_table(table_in_dataset, prompt_file, NLBQ())
+    else:
+        shutil.copyfile(package_dir / "templates" / "prompt.txt", prompt_file)
+
+    typer.echo(f"{prefix_success} Created prompt.txt at {prompt_file}")
 
 
 @app.command()

--- a/nlbq/cli.py
+++ b/nlbq/cli.py
@@ -1,6 +1,8 @@
+import shutil
 import sys
 from asyncio import run
 from functools import wraps
+from pathlib import Path
 
 import typer
 from tabulate import tabulate
@@ -51,7 +53,17 @@ async def ask(query: str, model: str = DEFAULT_MODEL) -> str:
 @app.command()
 def init():
     """Create stub files: prompt.txt, index.html, Dockerfile"""
-    print("Todo")
+    package_dir = Path(__file__).parent
+    for file in ["Dockerfile", "index.html", "prompt.txt"]:
+        dest = Path.cwd() / file
+        if dest.exists():
+            prefix = typer.style("✘", fg=typer.colors.RED, bold=True)
+            typer.echo(f"{prefix} {file} already exists here")
+            raise typer.Abort()
+        else:
+            shutil.copyfile(package_dir / "templates" / file, dest)
+            prefix = typer.style("✔", fg=typer.colors.GREEN, bold=True)
+            typer.echo(f"{prefix} Created {file} at {dest}")
 
 
 @app.command()

--- a/nlbq/helpers.py
+++ b/nlbq/helpers.py
@@ -1,0 +1,47 @@
+import json
+from datetime import date, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nlbq.core import NLBQ
+
+
+class CustomJsonEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, datetime | date):
+            return o.isoformat()
+        return super().default(o)
+
+
+def generate_prompt_from_dataset_table(
+    table_in_dataset: str, prompt_file: Path, nlbq: "NLBQ"
+):
+    """Generate a prompt file from a dataset and table"""
+    dataset_id, table_id = table_in_dataset.split(".")
+
+    fields = {
+        field.name: str(field)
+        for field in nlbq.client.get_table(table_in_dataset).schema
+    }
+
+    column_description_glue = ": add column description here\n"
+    content = prompt_file.read_text()
+    updated_content = (
+        content.replace("{{ project_id }}", nlbq.client.project)
+        .replace("{{ dataset }}", dataset_id)
+        .replace("{{ table_id }}", table_id)
+        .replace("{{ schema }}", "\n".join(fields.values()))
+        .replace(
+            "{{ columns }}",
+            column_description_glue.join(fields.keys()) + column_description_glue,
+        )
+    )
+
+    preview_rows = list(nlbq.client.list_rows(table_in_dataset, max_results=3))
+    preview = json.dumps(
+        [dict(row) for row in preview_rows], indent=2, cls=CustomJsonEncoder
+    )
+    updated_content = updated_content.replace("{{ preview }}", preview)
+
+    prompt_file.write_text(updated_content)

--- a/nlbq/templates/Dockerfile
+++ b/nlbq/templates/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim-buster
+
+EXPOSE 8080
+RUN pip install nlbq
+WORKDIR /app
+COPY ./ /app
+
+CMD ["nlbq"]

--- a/nlbq/templates/index.html
+++ b/nlbq/templates/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>NLBQ</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="https://unpkg.com/tachyons@4.12.0/css/tachyons.min.css" />
+  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+  <style>
+    th {
+      text-align: left;
+      font-weight: 500;
+    }
+    table {
+      border-spacing: 0 0.1em;
+    }
+    td {
+      padding-top: 0px;
+    }
+    .light-green {
+      color: aquamarine;
+    }
+  </style>
+</head>
+
+<body class="w-100 avenir black-80 bg-pink">
+  <div id="app" class="mw7 center pa2 black-80">
+    <div>
+      <h1 class="f-subheadline-ns f1 lh-solid mb4 near-black">
+        <span class="light-green">Natural Language</span> Big Query
+      </h1>
+      <form @submit="formSubmit">
+        <label for="question" class="f4 db mb3">Your question:</label>
+        <input id="question" class="input-reset f4 ba b--black-20 pa2 mb1 db w-100 br2" type="text"
+          v-model.lazy="question" />
+        <input id="submit" class="dim mt3 pointer ph3 pv2 input-reset ba b--black br2 bg-transparent f4 mb3"
+          type="submit" :value="button_text" />
+      </form>
+      <div class="mt0 f4" v-html="answer"></div>
+      <div class="mt3 mb2" v-if="answer.length">
+        <a class="light-green dim" href="#" @click="toggleText()">show workings</a>
+      </div>
+      <div id="context" v-if="sql.length" v-show="display" class="mv3 f5 bg-light-pink pt2 ph2 pb1 br2 lh-copy">
+        <span class="near-white">Query:</span>
+        <div v-html="sql" class="mv2"></div>
+        <span class="near-white">Results:</span>
+        <div v-html="results" class="mv2"></div>
+        <span class="near-white mt2">Cost:</span> ${{ cost }} ({{ tokens }}
+        tokens)<br />
+        <span class="near-white mt2">Timing:</span>
+        building query: {{ parseFloat(timings[0].toFixed(3)) }},
+        running query: {{ parseFloat(timings[1].toFixed(3)) }},
+        explaining results: {{ parseFloat(timings[2].toFixed(3)) }}
+      </div>
+    </div>
+  </div>
+
+  <script>
+    var app = new Vue({
+      el: "#app",
+      data: {
+        question: "",
+        answer: "",
+        results: "",
+        tokens: 0,
+        cost: 0,
+        timings: [],
+        sql: "",
+        button_text: "Tell me",
+        display: false,
+      },
+      methods: {
+        formSubmit(e) {
+          e.preventDefault();
+          app.button_text = "Working it out...";
+          app.answer = "";
+          app.sql = "";
+          api_url = "/api/ask?q=" + app.question;
+          fetch(api_url)
+            .then(async function (response) {
+              let json = await response.json();
+              let resp = json["response"];
+              app.answer = resp["answer"].replace(/\n/g, "<br />");
+              app.results = resp["results"];
+              app.plain_text_results = resp["plain_text_results"];
+              app.tokens = resp["tokens"];
+              app.sql = resp["sql"];
+              app.cost = parseFloat(resp["cost"].toFixed(4));
+              app.timings = resp["timings"];
+              app.button_text = "Tell me";
+            })
+            .catch(function (error) {
+              console.log(error);
+            });
+        },
+        toggleText() {
+          this.display = !this.display;
+        },
+      },
+    });
+  </script>
+</body>
+
+</html>

--- a/nlbq/templates/prompt.txt
+++ b/nlbq/templates/prompt.txt
@@ -1,0 +1,42 @@
+# Edit this file. You can leave comments like this one.
+I have a BigQuery dataset with one table. The project id is 'PROJECT_ID' and the dataset is 'DATASET.TABLE_NAME':
+
+# Describe the schema using the SchemaField class (https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.schema.SchemaField)
+SchemaField('domain', 'STRING', 'NULLABLE', None, None, (), None)
+SchemaField('pings', 'INTEGER', 'NULLABLE', None, None, (), None)
+SchemaField('first_seen', 'DATE', 'NULLABLE', None, None, (), None)
+SchemaField('last_seen', 'DATE', 'NULLABLE', None, None, (), None)
+
+# Describe the table
+It represents the referring domains. The columns are:
+
+# Describe each column using terms that are likely to be used in questions
+domain: the referrer domain
+pings: the total number of times the domain referenced the site
+first_seen: the date the referrer was first seen
+last_seen: the date the referrer was last seen
+
+# Provide a sample of the data.
+The rows look like this:
+
+[{
+  "domain": "duckduckgo.com",
+  "pings": "12720",
+  "first_seen": "2017-03-22",
+  "last_seen": "2023-05-16"
+}, {
+  "domain": "torchbox.com",
+  "pings": "10158",
+  "first_seen": "2019-03-19",
+  "last_seen": "2023-05-16"
+}, {
+  "domain": "example.com",
+  "pings": "9697",
+  "first_seen": "2018-05-25",
+  "last_seen": "2023-05-16"
+}]
+
+# Don't change the following lines
+Write a BigQuery query which answers this question: %s
+
+Don't explain it, just return the query.

--- a/nlbq/templates/prompt_template.txt
+++ b/nlbq/templates/prompt_template.txt
@@ -1,0 +1,20 @@
+# Edit this file. You can leave comments like this one.
+I have a BigQuery dataset with one table. The project id is '{{ project_id }}', the dataset is '{{ dataset }}' and the table is '{{ table_id }}':
+
+# Describe the schema using the SchemaField class (https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.schema.SchemaField)
+{{ schema }}
+
+# Describe the table, then describe each column using terms that are likely to be used in questions
+It represents the <insert description here>. The columns are:
+
+{{ columns }}
+
+# Provide a sample of the data.
+The rows look like this:
+
+{{ sample_data }}
+
+# Don't change the following lines
+Write a BigQuery query which answers this question: %s
+
+Don't explain it, just return the query.


### PR DESCRIPTION
This PR builds on #5 and #6 and adds a functional `nlbq init` command. It

* re-uses the template from nldb
* supports the `--table` option ((or `-t` shorhand)) that helps generate `prompt.txt` based on the provided table schema

Fixes #2. 
Note: while #2 mentions `--dataset`, we are looking at a particular table in a dataset, hence `--table`