### PR TITLE
Pass the OpenAI API key to ChatCompletions in NLBQ.answer()

### DIFF
--- a/nlbq/core.py
+++ b/nlbq/core.py
@@ -114,5 +114,6 @@ class NLBQ:
             model=self.model,
             messages=prompt_messages,
             temperature=0,
+            api_key=settings.openai_api_key,
         )
         return resp["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
This failed for me when running the answer.

<details>
<summary>Traceback</summary>

```
  File "/Users/dan/Sites/playground/nlbq/nlbq/api.py", line 82, in answer
    resp = await nlbq.answer(
           ^^^^^^^^^^^^^^^^^^
  File "/Users/dan/Sites/playground/nlbq/nlbq/core.py", line 114, in answer
    resp = await openai.ChatCompletion.acreate(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dan/Sites/playground/nlbq/demo/.venv/lib/python3.11/site-packages/openai/api_resources/chat_completion.py", line 45, in acreate
    return await super().acreate(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dan/Sites/playground/nlbq/demo/.venv/lib/python3.11/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 214, in acreate
    ) = cls.__prepare_create_request(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dan/Sites/playground/nlbq/demo/.venv/lib/python3.11/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 106, in __prepare_create_request
    requestor = api_requestor.APIRequestor(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dan/Sites/playground/nlbq/demo/.venv/lib/python3.11/site-packages/openai/api_requestor.py", line 134, in __init__
    self.api_key = key or util.default_api_key()
                          ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dan/Sites/playground/nlbq/demo/.venv/lib/python3.11/site-packages/openai/util.py", line 186, in default_api_key
    raise openai.error.AuthenticationError(
openai.error.AuthenticationError: No API key provided. You can set your API key in code using 'openai.api_key = <API-KEY>', or you can set the environment variable OPENAI_API_KEY=<API-KEY>). If your API key is stored in a file, you can point the openai module at it with 'openai.api_key_path = <PATH>'. You can generate API keys in the OpenAI web interface. See https://platform.openai.com/account/api-keys for details.
```
</details>